### PR TITLE
Refactor StageBuilderProcessor for clarity and consistency

### DIFF
--- a/processor/src/test/java/org/devnuxs/stagebuilder/processor/FunctionalStageBuilderTest.java
+++ b/processor/src/test/java/org/devnuxs/stagebuilder/processor/FunctionalStageBuilderTest.java
@@ -1,15 +1,24 @@
 package org.devnuxs.stagebuilder.processor;
 
 import com.google.testing.compile.JavaFileObjects;
+
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static com.google.testing.compile.CompilationSubject.assertThat;
 import static com.google.testing.compile.Compiler.javac;
 
+import java.util.Locale;
+
 /**
  * Tests for functional stage builder generation.
  */
 public class FunctionalStageBuilderTest {
+
+    @BeforeAll
+    public static void setup() {
+        Locale.setDefault(Locale.ENGLISH);
+    }
 
     @Test
     public void testStageBuilderEnforcesStrictStageOrdering() {

--- a/processor/src/test/java/org/devnuxs/stagebuilder/processor/OptionalFieldStageBuilderTest.java
+++ b/processor/src/test/java/org/devnuxs/stagebuilder/processor/OptionalFieldStageBuilderTest.java
@@ -1,15 +1,24 @@
 package org.devnuxs.stagebuilder.processor;
 
 import com.google.testing.compile.JavaFileObjects;
+
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static com.google.testing.compile.CompilationSubject.assertThat;
 import static com.google.testing.compile.Compiler.javac;
 
+import java.util.Locale;
+
 /**
  * Tests for optional field functionality in stage builders.
  */
 public class OptionalFieldStageBuilderTest {
+
+    @BeforeAll
+    public static void setup() {
+        Locale.setDefault(Locale.ENGLISH);
+    }
 
     @Test
     public void testOptionalFieldInClass() {


### PR DESCRIPTION
This commit introduces several refactorings in the StageBuilderProcessor class to improve readability and maintainability. Key changes include the introduction of constants for 'BuildStage' and 'Stage', as well as adjustments to method return types and interface names. These updates aim to streamline the code and enhance its clarity, particularly in the context of stage builder generation.